### PR TITLE
Rename some concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--time` argument to `start` command
 
 ### Changed
-- `Transitions` are now known as `Events`
+- `Transitions` renamed to `Events`
+- `week` command renamed to `chart`
 
 ## [0.1.1] - 2019-07-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--time` argument to `start` command
 
+### Changed
+- `Transitions` are now known as `Events`
+
 ## [0.1.1] - 2019-07-18
 ### Fixed
 - Empty device files will no longer cause `augr` to crash

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Date  Start Duration Total     Tags
       14:54 53m      4h 57m    augr
 ```
 
-The `week` subcommand will give a graphical overview of the past 7 days:
+The `chart` subcommand will give a graphical overview of the past 7 days:
 
 ```sh
-$ augr week augr
+$ augr chart augr
 Day 0  1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19 20 21 22 23 
 Sun                                                                         
 Mon                                                                         

--- a/cli/src/chart.rs
+++ b/cli/src/chart.rs
@@ -4,19 +4,21 @@ use std::collections::BTreeSet;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
-#[structopt(name = "week")]
-pub struct ShowWeekCmd {
+#[structopt(name = "chart")]
+pub struct Cmd {
     /// A list of tags to filter against
     tags: Vec<String>,
 
+    /// The date to start charting from. Defaults to 7 days ago.
     #[structopt(long = "start")]
     start: Option<NaiveDate>,
 
+    /// The date to stop charting at. Defaults to today.
     #[structopt(long = "end")]
     end: Option<NaiveDate>,
 }
 
-impl ShowWeekCmd {
+impl Cmd {
     pub fn exec<DB: DataBase>(&self, timesheet: &DB) {
         let tags: BTreeSet<Tag> = self.tags.iter().cloned().map(Tag::from).collect();
 

--- a/cli/src/database.rs
+++ b/cli/src/database.rs
@@ -3,11 +3,11 @@ use chrono::{DateTime, Utc};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub trait DataBase {
-    fn transitions(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>>;
-    fn insert_transition(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>);
+    fn events(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>>;
+    fn insert_event(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>);
 
     fn tags_at_time<'ts>(&'ts self, datetime: &DateTime<Utc>) -> Option<&'ts BTreeSet<Tag>> {
-        self.transitions()
+        self.events()
             .range::<DateTime<_>, _>(..datetime)
             .map(|(_time, tags)| *tags)
             .last()
@@ -16,10 +16,10 @@ pub trait DataBase {
     fn segments(&self) -> Vec<Segment> {
         let now = Utc::now();
         let end_cap_arr = [&now];
-        let transitions = self.transitions();
-        transitions
+        let events = self.events();
+        events
             .iter()
-            .zip(transitions.keys().skip(1).chain(end_cap_arr.iter()))
+            .zip(events.keys().skip(1).chain(end_cap_arr.iter()))
             .map(|(t, end_time)| {
                 let duration = end_time.signed_duration_since(**t.0);
                 Segment {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 mod config;
 mod database;
-mod show_week;
+mod chart;
 mod start;
 mod summary;
 mod sync_folder_db;
@@ -26,8 +26,8 @@ enum Command {
     #[structopt(name = "summary")]
     Summary(summary::SummaryCmd),
 
-    #[structopt(name = "week")]
-    Week(show_week::ShowWeekCmd),
+    #[structopt(name = "chart")]
+    Chart(chart::Cmd),
 
     #[structopt(name = "tags")]
     Tags(tags::TagsCmd),
@@ -71,7 +71,7 @@ fn run() -> Result<(), Error> {
     match opt.cmd.unwrap_or(Command::default()) {
         Command::Start(subcmd) => subcmd.exec(&mut db),
         Command::Summary(subcmd) => subcmd.exec(&db),
-        Command::Week(subcmd) => subcmd.exec(&db),
+        Command::Chart(subcmd) => subcmd.exec(&db),
         Command::Tags(subcmd) => subcmd.exec(&db),
     }
 

--- a/cli/src/start.rs
+++ b/cli/src/start.rs
@@ -21,6 +21,6 @@ impl StartCmd {
             .unwrap_or(Utc::now());
         let tags: BTreeSet<Tag> = self.tags.iter().cloned().map(Tag::from).collect();
 
-        db.insert_transition(now, tags);
+        db.insert_event(now, tags);
     }
 }

--- a/cli/src/sync_folder_db.rs
+++ b/cli/src/sync_folder_db.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::DataBase,
-    timesheet::{load_transitions, save_timesheet, Tag, Timesheet},
+    timesheet::{load_events, save_timesheet, Tag, Timesheet},
 };
 use chrono::{DateTime, Utc};
 use snafu::{ResultExt, Snafu};
@@ -42,7 +42,7 @@ impl SyncFolderDB {
         let mut device_timesheet = Timesheet::new();
 
         if device_path.exists() {
-            load_transitions(&device_path, &mut device_timesheet).context(ReadFile {
+            load_events(&device_path, &mut device_timesheet).context(ReadFile {
                 path: device_path.to_path_buf(),
             })?;
         }
@@ -65,7 +65,7 @@ impl SyncFolderDB {
             if !path.is_file() {
                 continue;
             }
-            load_transitions(&path, &mut db.global_timesheet).context(ReadFile { path })?;
+            load_events(&path, &mut db.global_timesheet).context(ReadFile { path })?;
         }
 
         Ok(db)
@@ -80,13 +80,13 @@ impl SyncFolderDB {
 }
 
 impl DataBase for SyncFolderDB {
-    fn transitions(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>> {
-        self.global_timesheet.transitions()
+    fn events(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>> {
+        self.global_timesheet.events()
     }
 
-    fn insert_transition(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>) {
+    fn insert_event(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>) {
         self.device_timesheet
-            .insert_transition(datetime.clone(), tags.clone());
-        self.global_timesheet.insert_transition(datetime, tags);
+            .insert_event(datetime.clone(), tags.clone());
+        self.global_timesheet.insert_event(datetime, tags);
     }
 }

--- a/cli/src/tags.rs
+++ b/cli/src/tags.rs
@@ -8,7 +8,7 @@ pub struct TagsCmd {}
 impl TagsCmd {
     pub fn exec<DB: DataBase>(&self, timesheet: &DB) {
         let tags: BTreeSet<Tag> = timesheet
-            .transitions()
+            .events()
             .iter()
             .fold(BTreeSet::new(), |acc, x| acc.union(x.1).cloned().collect());
 

--- a/cli/src/timesheet.rs
+++ b/cli/src/timesheet.rs
@@ -10,7 +10,7 @@ use std::{
 
 #[derive(Clone, Debug)]
 pub struct Timesheet {
-    transitions: BTreeMap<DateTime<Utc>, BTreeSet<Tag>>,
+    events: BTreeMap<DateTime<Utc>, BTreeSet<Tag>>,
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -27,18 +27,18 @@ pub struct Segment {
 impl Timesheet {
     pub fn new() -> Timesheet {
         Self {
-            transitions: BTreeMap::new(),
+            events: BTreeMap::new(),
         }
     }
 }
 
 impl DataBase for Timesheet {
-    fn transitions(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>> {
-        self.transitions.iter().collect()
+    fn events(&self) -> BTreeMap<&DateTime<Utc>, &BTreeSet<Tag>> {
+        self.events.iter().collect()
     }
 
-    fn insert_transition(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>) {
-        self.transitions.insert(datetime, tags);
+    fn insert_event(&mut self, datetime: DateTime<Utc>, tags: BTreeSet<Tag>) {
+        self.events.insert(datetime, tags);
     }
 }
 
@@ -64,7 +64,7 @@ pub enum Error {
     },
 }
 
-pub fn load_transitions(path: &Path, timesheet: &mut Timesheet) -> Result<(), Error> {
+pub fn load_events(path: &Path, timesheet: &mut Timesheet) -> Result<(), Error> {
     let contents = read_to_string(path).context(ReadTimesheet { path })?;
 
     if contents.trim() == "" {
@@ -79,7 +79,7 @@ pub fn load_transitions(path: &Path, timesheet: &mut Timesheet) -> Result<(), Er
             .parse()
             .context(DateTimeParse { line_number, path })?;
         let tags = cols.map(|x| Tag(x.into())).collect();
-        timesheet.transitions.insert(time, tags);
+        timesheet.events.insert(time, tags);
     }
 
     Ok(())
@@ -95,7 +95,7 @@ pub fn save_timesheet(path: &Path, timesheet: &Timesheet) -> Result<(), Error> {
         .open(path)
         .context(WriteTimesheet { path })?;
 
-    for (start_time, tags) in timesheet.transitions.iter() {
+    for (start_time, tags) in timesheet.events.iter() {
         write!(wtr, "{}", start_time.to_rfc3339()).unwrap();
         for t in tags {
             write!(wtr, " {}", t.0).unwrap();


### PR DESCRIPTION
Renaming some concepts.
- `transition` -> `event`: I didn't really like the name transition. I think `event` is a more concise term, even if it doesn't make the definition any more clear that it was before.
- `week` -> `chart`: `timewarrior` used `week` and `month` for different duration of the same command, but I'm aiming to have a more traditional CLI as compared to `timewarrior`.